### PR TITLE
Minimal memory leak fix for postJson()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appliedblockchain/helpers",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "No dependency, single file helpers.",
   "main": "index.js",
   "scripts": {

--- a/post-json.js
+++ b/post-json.js
@@ -103,7 +103,8 @@ function postJsonNoRetry(
         const headers = res.headers
         const buffer = Buffer.concat(chunks)
         const json = parseJson(buffer.toString('utf8'))
-        req.emit('settle', void 0, { code, headers, json, buffer })
+        resolve({ code, headers, json, buffer })
+        // req.emit('settle', void 0, { code, headers, json, buffer })
       })
       res.on('error', err => req.emit('settle', err))
     })


### PR DESCRIPTION
This should fix the memory leak. I believe because of nested EventEmitters keeping promises around (Node not being able to free the allocated promises which contain the request object and data which doesn't gets freed). I'm not 100% sure but after the change in this one-line commit, the memory doesn't seem to rise anymore.

Someone needs to:
- take ownership of this PR or open another branch/PR and close this
- re-check if this is actually the case on your copy of SLB  (use one of the two techniques posted in slack to inspect the app memory https://appliedblockchain.slack.com/archives/G43SK2Y6N/p1558598347003700 ) 
- finish the implementation (you can see that this doesn't fixes memory leaks in error-cases) or decide to push forward with just a simple fix like this

I suggest to test by running `strading-slb` with the required debugging options (`LOG=debug node --inspect --expose-gc bin/start.js `) and applying changes directly to the `@appliedblockchain/helpers/post-json` file

note: run `docker run -p 8545:8545 appliedblockchain/parity-solo` to run slb locally or set the PEERS env vars to QA parity hosts